### PR TITLE
Order txs by descending order

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,16 @@ This version of Ping.Pub was forked from from commit https://github.com/ping-pub
   - Removed any existing chains.
   - Added `fuel.json`.
   - Added `fuel-testnet.json`.
+- `src/libs/`
+  - In `client.ts`, added `order_by=2` to `getTxsBySender` query, for DESC ordering.
 - `src/layouts/components/`:
   - Removed Sponsors from `DefaultLayout.vue`.
 - `src/modules/[chain]`:
   - In `indexStore.ts` add **Initial Supply** card.
   - In `indexStore.ts` remove **Validators** card.
   - In `indexStore.ts` rename **Supply** card to **Supply on Sequencer**.
+- `src/modules/[chain]/account`:
+  - In `[address].vue`, added `order_by=2` to `receivedQuery` query, for DESC ordering.
 - `src/modules/[chain]/supply`:
   - In `index.vue` add `fuel (initial_supply)`.
   - In `index.vue` change fuel supply to `fuel (supply_on_sequencer)`.

--- a/src/libs/client.ts
+++ b/src/libs/client.ts
@@ -279,9 +279,9 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
   async getTxsBySender(sender: string, page?: PageRequest) {
     if(!page) page = new PageRequest()
 
-    let query = `?events=message.sender='${sender}'&pagination.limit=${page.limit}&pagination.offset=${page.offset||0}`;
+    let query = `?order_by=2&events=message.sender='${sender}'&pagination.limit=${page.limit}&pagination.offset=${page.offset||0}`;
     if (semver.gte(this.version.replaceAll('v', ''), '0.50.0')) {
-      query = `?query=message.sender='${sender}'&pagination.limit=${page.limit}&pagination.offset=${page.offset||0}`;
+      query = `?order_by=2&query=message.sender='${sender}'&pagination.limit=${page.limit}&pagination.offset=${page.offset||0}`;
     }
     return this.request(this.registry.tx_txs, {}, query);
   }

--- a/src/modules/[chain]/account/[address].vue
+++ b/src/modules/[chain]/account/[address].vue
@@ -113,7 +113,7 @@ function loadAccount(address: string) {
     });
   });
 
-  const receivedQuery =  `?&pagination.reverse=true&events=coin_received.receiver='${address}'&pagination.limit=5`;
+  const receivedQuery =  `?order_by=2&events=coin_received.receiver='${address}'&pagination.limit=5`;
   blockchain.rpc.getTxs(receivedQuery, {}).then((x) => {
     recentReceived.value = x.tx_responses;
   });


### PR DESCRIPTION
Since we show a limited number of txs on an account page, we should at least return the latest txs not the oldest ones.